### PR TITLE
Add Django skeleton for factura IA

### DIFF
--- a/factura/README.md
+++ b/factura/README.md
@@ -1,0 +1,29 @@
+# Factura IA
+
+Sistema de facturación inteligente construido con Django y Django REST Framework.
+
+## Características
+
+- Autenticación de usuarios.
+- CRUD de clientes y productos.
+- Gestión de facturas y actualización de stock.
+- Generación de predicciones y análisis mediante OpenAI.
+- API REST para integración con frontends.
+
+## Instalación
+
+1. Crear un entorno virtual y activar.
+2. Instalar dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Ejecutar migraciones:
+   ```bash
+   python manage.py migrate
+   ```
+4. Iniciar el servidor:
+   ```bash
+   python manage.py runserver
+   ```
+
+Este proyecto usa SQLite por defecto para facilitar pruebas locales.

--- a/factura/analytics/__init__.py
+++ b/factura/analytics/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'analytics.apps.AnalyticsConfig'

--- a/factura/analytics/ai.py
+++ b/factura/analytics/ai.py
@@ -1,0 +1,28 @@
+"""Placeholder AI module using OpenAI API."""
+import logging
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai may not be installed
+    openai = None
+
+logger = logging.getLogger(__name__)
+
+API_MODEL = 'gpt-4'
+
+def predict_sales(prompt: str) -> str:
+    """Return sales prediction from OpenAI."""
+    if openai is None:
+        logger.warning('openai not installed')
+        return 'Prediction unavailable'
+    response = openai.ChatCompletion.create(model=API_MODEL, messages=[{"role": "user", "content": prompt}])
+    return response.choices[0].message['content']
+
+def detect_irregularities(data: str) -> str:
+    """Analyze data for potential irregularities."""
+    if openai is None:
+        logger.warning('openai not installed')
+        return 'No analysis available'
+    prompt = f"Detect irregularities in: {data}"
+    response = openai.ChatCompletion.create(model=API_MODEL, messages=[{"role": "user", "content": prompt}])
+    return response.choices[0].message['content']

--- a/factura/analytics/apps.py
+++ b/factura/analytics/apps.py
@@ -1,0 +1,4 @@
+from django.apps import AppConfig
+
+class AnalyticsConfig(AppConfig):
+    name = 'analytics'

--- a/factura/billing/__init__.py
+++ b/factura/billing/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'billing.apps.BillingConfig'

--- a/factura/billing/apps.py
+++ b/factura/billing/apps.py
@@ -1,0 +1,4 @@
+from django.apps import AppConfig
+
+class BillingConfig(AppConfig):
+    name = 'billing'

--- a/factura/billing/auth_views.py
+++ b/factura/billing/auth_views.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.models import User
+from rest_framework import generics
+from rest_framework.permissions import AllowAny
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework import status
+from django.contrib.auth import authenticate
+
+class RegisterView(generics.CreateAPIView):
+    queryset = User.objects.all()
+    permission_classes = [AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        username = request.data.get('username')
+        password = request.data.get('password')
+        if not username or not password:
+            return Response({'error': 'username and password required'}, status=status.HTTP_400_BAD_REQUEST)
+        if User.objects.filter(username=username).exists():
+            return Response({'error': 'user exists'}, status=status.HTTP_400_BAD_REQUEST)
+        user = User.objects.create_user(username=username, password=password)
+        token, _ = Token.objects.get_or_create(user=user)
+        return Response({'token': token.key})
+
+class LoginView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        username = request.data.get('username')
+        password = request.data.get('password')
+        user = authenticate(username=username, password=password)
+        if user is None:
+            return Response({'error': 'invalid credentials'}, status=status.HTTP_400_BAD_REQUEST)
+        token, _ = Token.objects.get_or_create(user=user)
+        return Response({'token': token.key})

--- a/factura/billing/models.py
+++ b/factura/billing/models.py
@@ -1,0 +1,29 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+class Client(models.Model):
+    name = models.CharField(max_length=100)
+    email = models.EmailField(unique=True)
+    address = models.TextField(blank=True)
+
+    def __str__(self):
+        return self.name
+
+class Product(models.Model):
+    name = models.CharField(max_length=100)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    stock = models.PositiveIntegerField(default=0)
+
+    def __str__(self):
+        return self.name
+
+class Invoice(models.Model):
+    client = models.ForeignKey(Client, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+    total = models.DecimalField(max_digits=10, decimal_places=2)
+
+class InvoiceItem(models.Model):
+    invoice = models.ForeignKey(Invoice, related_name='items', on_delete=models.CASCADE)
+    product = models.ForeignKey(Product, on_delete=models.CASCADE)
+    quantity = models.PositiveIntegerField()
+    price = models.DecimalField(max_digits=10, decimal_places=2)

--- a/factura/billing/pdf.py
+++ b/factura/billing/pdf.py
@@ -1,0 +1,25 @@
+"""Simple PDF generation placeholder."""
+from datetime import datetime
+
+try:
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+except ImportError:  # pragma: no cover
+    letter = None
+    canvas = None
+
+
+def generate_invoice_pdf(invoice, path: str):
+    """Generate a PDF for the given invoice."""
+    if canvas is None:
+        with open(path, 'w') as f:
+            f.write(f'Invoice {invoice.id} - {datetime.now()}')
+        return
+    c = canvas.Canvas(path, pagesize=letter)
+    c.drawString(100, 750, f'Invoice {invoice.id}')
+    y = 720
+    for item in invoice.items.all():
+        c.drawString(100, y, f'{item.product.name}: {item.quantity} x {item.price}')
+        y -= 20
+    c.drawString(100, y - 20, f'Total: {invoice.total}')
+    c.save()

--- a/factura/billing/serializers.py
+++ b/factura/billing/serializers.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+from .models import Client, Product, Invoice, InvoiceItem
+
+class ClientSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Client
+        fields = '__all__'
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = '__all__'
+
+class InvoiceItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = InvoiceItem
+        fields = '__all__'
+
+class InvoiceSerializer(serializers.ModelSerializer):
+    items = InvoiceItemSerializer(many=True)
+
+    class Meta:
+        model = Invoice
+        fields = ['id', 'client', 'created_at', 'total', 'items']
+
+    def create(self, validated_data):
+        items_data = validated_data.pop('items')
+        invoice = Invoice.objects.create(**validated_data)
+        total = 0
+        for item in items_data:
+            product = item['product']
+            quantity = item['quantity']
+            price = product.price * quantity
+            InvoiceItem.objects.create(invoice=invoice, product=product, quantity=quantity, price=price)
+            total += price
+            product.stock = max(product.stock - quantity, 0)
+            product.save()
+        invoice.total = total
+        invoice.save()
+        return invoice

--- a/factura/billing/urls.py
+++ b/factura/billing/urls.py
@@ -1,0 +1,14 @@
+from rest_framework import routers
+from django.urls import path
+from .views import ClientViewSet, ProductViewSet, InvoiceViewSet
+from .auth_views import RegisterView, LoginView
+
+router = routers.DefaultRouter()
+router.register(r'clients', ClientViewSet)
+router.register(r'products', ProductViewSet)
+router.register(r'invoices', InvoiceViewSet)
+
+urlpatterns = router.urls + [
+    path('register/', RegisterView.as_view(), name='register'),
+    path('login/', LoginView.as_view(), name='login'),
+]

--- a/factura/billing/views.py
+++ b/factura/billing/views.py
@@ -1,0 +1,25 @@
+from rest_framework import viewsets, decorators, response
+from .models import Client, Product, Invoice
+from .serializers import ClientSerializer, ProductSerializer, InvoiceSerializer
+from .pdf import generate_invoice_pdf
+
+class ClientViewSet(viewsets.ModelViewSet):
+    queryset = Client.objects.all()
+    serializer_class = ClientSerializer
+
+class ProductViewSet(viewsets.ModelViewSet):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+
+class InvoiceViewSet(viewsets.ModelViewSet):
+    queryset = Invoice.objects.all()
+    serializer_class = InvoiceSerializer
+
+    @decorators.action(detail=True, methods=['get'])
+    def pdf(self, request, pk=None):
+        invoice = self.get_object()
+        path = f'invoice_{invoice.id}.pdf'
+        generate_invoice_pdf(invoice, path)
+        with open(path, 'rb') as f:
+            data = f.read()
+        return response.Response(data, content_type='application/pdf')

--- a/factura/factura/settings.py
+++ b/factura/factura/settings.py
@@ -1,0 +1,67 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SECRET_KEY = 'changeme'
+DEBUG = True
+ALLOWED_HOSTS = []
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework.authtoken',
+    'rest_framework',
+    'billing',
+    'analytics',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'factura.urls'
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+WSGI_APPLICATION = 'factura.wsgi.application'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.TokenAuthentication'],
+}
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+
+STATIC_URL = '/static/'

--- a/factura/factura/urls.py
+++ b/factura/factura/urls.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('api/', include('billing.urls')),
+]

--- a/factura/factura/wsgi.py
+++ b/factura/factura/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'factura.settings')
+application = get_wsgi_application()

--- a/factura/manage.py
+++ b/factura/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'factura.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed?"
+        ) from exc
+    execute_from_command_line(sys.argv)

--- a/factura/requirements.txt
+++ b/factura/requirements.txt
@@ -1,0 +1,3 @@
+django>=4.2
+djangorestframework
+openai


### PR DESCRIPTION
## Summary
- scaffold a Django billing project with clients, products, invoices and auth
- include OpenAI-based analytics placeholders
- provide requirements and usage instructions

## Testing
- `python manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6850e6d23a708332a732c1410eeb3fe2