### PR TITLE
Add documentation and in-memory PDF generation

### DIFF
--- a/factura/README.md
+++ b/factura/README.md
@@ -10,6 +10,9 @@ Sistema de facturación inteligente construido con Django y Django REST Framewor
 - Generación de predicciones y análisis mediante OpenAI.
 - API REST para integración con frontends.
 
+Este repositorio solo incluye el backend; se puede conectar con
+cualquier frontend profesional que consuma la API.
+
 ## Instalación
 
 1. Crear un entorno virtual y activar.

--- a/factura/analytics/__init__.py
+++ b/factura/analytics/__init__.py
@@ -1,1 +1,3 @@
+"""Analytics application package."""
+
 default_app_config = 'analytics.apps.AnalyticsConfig'

--- a/factura/analytics/ai.py
+++ b/factura/analytics/ai.py
@@ -1,4 +1,4 @@
-"""Placeholder AI module using OpenAI API."""
+"""Minimal AI helpers built on top of the OpenAI API."""
 import logging
 
 try:

--- a/factura/analytics/apps.py
+++ b/factura/analytics/apps.py
@@ -1,4 +1,8 @@
+"""Django application configuration for analytics."""
+
 from django.apps import AppConfig
 
 class AnalyticsConfig(AppConfig):
+    """App configuration."""
+
     name = 'analytics'

--- a/factura/billing/__init__.py
+++ b/factura/billing/__init__.py
@@ -1,1 +1,3 @@
+"""Billing application package."""
+
 default_app_config = 'billing.apps.BillingConfig'

--- a/factura/billing/apps.py
+++ b/factura/billing/apps.py
@@ -1,4 +1,8 @@
+"""Django application configuration for billing."""
+
 from django.apps import AppConfig
 
 class BillingConfig(AppConfig):
+    """App configuration."""
+
     name = 'billing'

--- a/factura/billing/auth_views.py
+++ b/factura/billing/auth_views.py
@@ -1,17 +1,22 @@
+"""Authentication helpers for the billing API."""
+
 from django.contrib.auth.models import User
-from rest_framework import generics
+from rest_framework import generics, status
 from rest_framework.permissions import AllowAny
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework import status
 from django.contrib.auth import authenticate
 
 class RegisterView(generics.CreateAPIView):
+    """Create a new user and return an auth token."""
+
     queryset = User.objects.all()
     permission_classes = [AllowAny]
 
     def post(self, request, *args, **kwargs):
+        """Validate input, create the user and return a token."""
+
         username = request.data.get('username')
         password = request.data.get('password')
         if not username or not password:
@@ -23,9 +28,13 @@ class RegisterView(generics.CreateAPIView):
         return Response({'token': token.key})
 
 class LoginView(APIView):
+    """Authenticate an existing user and return a token."""
+
     permission_classes = [AllowAny]
 
     def post(self, request):
+        """Validate credentials and issue an auth token."""
+
         username = request.data.get('username')
         password = request.data.get('password')
         user = authenticate(username=username, password=password)

--- a/factura/billing/models.py
+++ b/factura/billing/models.py
@@ -1,7 +1,11 @@
+"""Database models for the billing application."""
+
 from django.db import models
 from django.contrib.auth.models import User
 
 class Client(models.Model):
+    """Customer data."""
+
     name = models.CharField(max_length=100)
     email = models.EmailField(unique=True)
     address = models.TextField(blank=True)
@@ -10,6 +14,8 @@ class Client(models.Model):
         return self.name
 
 class Product(models.Model):
+    """Item that can be sold."""
+
     name = models.CharField(max_length=100)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     stock = models.PositiveIntegerField(default=0)
@@ -18,11 +24,15 @@ class Product(models.Model):
         return self.name
 
 class Invoice(models.Model):
+    """Record of a sale."""
+
     client = models.ForeignKey(Client, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)
     total = models.DecimalField(max_digits=10, decimal_places=2)
 
 class InvoiceItem(models.Model):
+    """Line item belonging to an :class:`Invoice`."""
+
     invoice = models.ForeignKey(Invoice, related_name='items', on_delete=models.CASCADE)
     product = models.ForeignKey(Product, on_delete=models.CASCADE)
     quantity = models.PositiveIntegerField()

--- a/factura/billing/serializers.py
+++ b/factura/billing/serializers.py
@@ -1,22 +1,33 @@
+"""Serializers translating billing models to JSON and back."""
+
 from rest_framework import serializers
+
 from .models import Client, Product, Invoice, InvoiceItem
 
 class ClientSerializer(serializers.ModelSerializer):
+    """Serializer for :class:`Client` instances."""
+
     class Meta:
         model = Client
         fields = '__all__'
 
 class ProductSerializer(serializers.ModelSerializer):
+    """Serializer for :class:`Product` instances."""
+
     class Meta:
         model = Product
         fields = '__all__'
 
 class InvoiceItemSerializer(serializers.ModelSerializer):
+    """Serializer for invoice line items."""
+
     class Meta:
         model = InvoiceItem
         fields = '__all__'
 
 class InvoiceSerializer(serializers.ModelSerializer):
+    """Serializer for invoices including related items."""
+
     items = InvoiceItemSerializer(many=True)
 
     class Meta:
@@ -24,17 +35,27 @@ class InvoiceSerializer(serializers.ModelSerializer):
         fields = ['id', 'client', 'created_at', 'total', 'items']
 
     def create(self, validated_data):
+        """Create an invoice along with its items and update stock."""
+
         items_data = validated_data.pop('items')
         invoice = Invoice.objects.create(**validated_data)
+
         total = 0
         for item in items_data:
             product = item['product']
             quantity = item['quantity']
             price = product.price * quantity
-            InvoiceItem.objects.create(invoice=invoice, product=product, quantity=quantity, price=price)
+            InvoiceItem.objects.create(
+                invoice=invoice,
+                product=product,
+                quantity=quantity,
+                price=price,
+            )
             total += price
+            # Reduce stock but never go negative
             product.stock = max(product.stock - quantity, 0)
             product.save()
+
         invoice.total = total
         invoice.save()
         return invoice

--- a/factura/billing/urls.py
+++ b/factura/billing/urls.py
@@ -1,5 +1,8 @@
+"""Route definitions for the billing API."""
+
 from rest_framework import routers
 from django.urls import path
+
 from .views import ClientViewSet, ProductViewSet, InvoiceViewSet
 from .auth_views import RegisterView, LoginView
 

--- a/factura/billing/views.py
+++ b/factura/billing/views.py
@@ -1,25 +1,33 @@
+"""REST API views for the billing application."""
+
 from rest_framework import viewsets, decorators, response
+
 from .models import Client, Product, Invoice
 from .serializers import ClientSerializer, ProductSerializer, InvoiceSerializer
 from .pdf import generate_invoice_pdf
 
 class ClientViewSet(viewsets.ModelViewSet):
+    """CRUD operations for :class:`Client` objects."""
+
     queryset = Client.objects.all()
     serializer_class = ClientSerializer
 
 class ProductViewSet(viewsets.ModelViewSet):
+    """CRUD operations for :class:`Product` objects."""
+
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
 
 class InvoiceViewSet(viewsets.ModelViewSet):
+    """Manage invoices and provide PDF exports."""
+
     queryset = Invoice.objects.all()
     serializer_class = InvoiceSerializer
 
     @decorators.action(detail=True, methods=['get'])
     def pdf(self, request, pk=None):
+        """Return the invoice PDF."""
+
         invoice = self.get_object()
-        path = f'invoice_{invoice.id}.pdf'
-        generate_invoice_pdf(invoice, path)
-        with open(path, 'rb') as f:
-            data = f.read()
+        data = generate_invoice_pdf(invoice)
         return response.Response(data, content_type='application/pdf')

--- a/factura/factura/__init__.py
+++ b/factura/factura/__init__.py
@@ -1,0 +1,1 @@
+"""Factura project package."""

--- a/factura/factura/settings.py
+++ b/factura/factura/settings.py
@@ -1,3 +1,5 @@
+"""Minimal Django settings for the Factura project."""
+
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/factura/factura/urls.py
+++ b/factura/factura/urls.py
@@ -1,3 +1,5 @@
+"""URL configuration for the Factura project."""
+
 from django.contrib import admin
 from django.urls import path, include
 

--- a/factura/factura/wsgi.py
+++ b/factura/factura/wsgi.py
@@ -1,3 +1,5 @@
+"""WSGI entry point for the Factura project."""
+
 import os
 from django.core.wsgi import get_wsgi_application
 

--- a/factura/manage.py
+++ b/factura/manage.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+"""Django management utility."""
+
 import os
 import sys
 


### PR DESCRIPTION
## Summary
- add thorough module and class docstrings
- generate PDFs directly in memory
- clarify that repository is backend-only

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850e93961348332b852f0cd0b186356